### PR TITLE
Fix promotion display: extract productId from promotionProducts array

### DIFF
--- a/PROMOTION_CRUD_DOCUMENTATION.md
+++ b/PROMOTION_CRUD_DOCUMENTATION.md
@@ -1,0 +1,295 @@
+# Promotion CRUD Operations - Frontend Documentation
+
+## Overview
+This document outlines how the frontend handles Promotion CRUD operations and the required backend API contract.
+
+---
+
+## Frontend Operations
+
+### 1. **READ Operations**
+
+#### Get All Promotions
+- **Endpoint**: `GET /promotions`
+- **Frontend Function**: `findPromotions()`
+- **Usage**: Admin view to see all promotions (active and inactive)
+- **Location**: `app/(admin)/view-promotion.tsx`
+
+#### Get Active Promotions
+- **Endpoint**: `GET /promotions/active`
+- **Frontend Function**: `findActivePromotions(storeId?: number)`
+- **Usage**: 
+  - Consumer home page
+  - Retailer dashboard
+  - Store details page
+- **Filtering**: If `storeId` is provided, frontend filters by store ownership
+
+#### Get Promotion by ID
+- **Endpoint**: `GET /promotions/{id}`
+- **Frontend Function**: `findPromotionById(promotionId)`
+- **Usage**: Fetch single promotion details
+
+---
+
+### 2. **CREATE Operation**
+
+#### Create Promotion
+- **Endpoint**: `POST /promotions`
+- **Frontend Function**: `createPromotion(data)`
+- **Request Payload**:
+```typescript
+{
+  title: string;
+  type: string; // "percentage" | "fixed" (case-insensitive)
+  description: string;
+  discount: number;
+  productIds: number[]; // Array of product IDs
+  startsAt?: string; // ISO 8601 format
+  endsAt?: string | null; // ISO 8601 format
+  active?: boolean;
+}
+```
+
+- **Usage**: 
+  - Retailers create promotions via `app/(retailers)/promotions.tsx`
+  - Frontend sends `productIds` array (not `productId`)
+  - Creates one promotion per product with individual discounts
+
+#### Add Products to Promotion
+- **Endpoint**: `POST /promotions/{id}/products`
+- **Frontend Function**: `addProductsToPromotion(promotionId, data)`
+- **Request Payload**:
+```typescript
+{
+  productIds: number[];
+}
+```
+- **Usage**: Add additional products to existing promotion
+- **Tier Restrictions**: 
+  - BASIC tier: max 10 products per promotion
+  - PRO tier: unlimited products
+
+---
+
+### 3. **UPDATE Operation**
+
+#### Update Promotion
+- **Endpoint**: `PATCH /promotions/{id}`
+- **Frontend Function**: `updatePromotion({ id, ...data })`
+- **Request Payload** (all fields optional):
+```typescript
+{
+  id: number;
+  title?: string;
+  type?: string;
+  description?: string;
+  discount?: number;
+  startsAt?: string;
+  endsAt?: string | null;
+  active?: boolean;
+}
+```
+
+- **Usage**: 
+  - Admin can toggle `active` status in `app/(admin)/view-promotion.tsx`
+  - Retailers can edit promotions in `app/(retailers)/promotions.tsx`
+
+---
+
+### 4. **DELETE Operation**
+
+#### Delete Promotion
+- **Endpoint**: `DELETE /promotions/{id}`
+- **Frontend Function**: `deletePromotion(promotionId)`
+- **Usage**: Admin can delete promotions from `app/(admin)/view-promotion.tsx`
+
+---
+
+## Expected Response Structure
+
+### PromotionResponseDto
+According to the OpenAPI schema, the backend should return:
+
+```typescript
+{
+  id: number;
+  title: string;
+  type: string; // "PERCENTAGE" or "FIXED" (uppercase from API, frontend handles case-insensitive)
+  description: string;
+  startsAt: string; // ISO 8601 format date-time
+  endsAt: string | null; // ISO 8601 format date-time
+  active: boolean;
+  discount: number;
+  productId: number | null; // ⚠️ CRITICAL: Must be populated for frontend to work
+}
+```
+
+**OpenAPI Schema Reference**: The schema defines `productId` as nullable (`"nullable": true`), but it should be populated with a value (not null) when the promotion has products.
+
+---
+
+## ⚠️ CRITICAL BACKEND REQUIREMENTS
+
+### Issue: Missing `productId` Field
+
+**Problem**: The frontend code relies on `productId` field to:
+1. Display product names in promotion lists
+2. Filter promotions by product
+3. Search promotions by product name
+4. Determine if promotion is "orphaned" (product/store doesn't exist)
+
+**Current Backend Response** (❌ Broken):
+```json
+{
+  "id": 28,
+  "title": "Sueu",
+  "type": "percentage",
+  "productId": null,  // ❌ This is null (schema allows nullable but frontend needs a value)
+  "promotionProducts": [  // Products are here but frontend doesn't use this
+    {
+      "productId": 81,
+      "product": { ... }
+    }
+  ]
+}
+```
+
+**Required Backend Response** (✅ Fixed):
+```json
+{
+  "id": 28,
+  "title": "Sueu",
+  "type": "percentage",
+  "productId": 81,  // ✅ Must be populated (first product's ID from promotionProducts)
+  // Note: promotionProducts array can still be included for detailed product info
+}
+```
+
+### Backend Fix Required
+
+**According to OpenAPI Schema**: The `PromotionResponseDto` schema defines `productId` as:
+- Type: `object` (should be `number`)
+- Nullable: `true`
+- Description: "Product ID (nullable)"
+
+**Required Implementation**:
+1. **Populate `productId` from `promotionProducts` array**
+   - When building the response, extract the first product's ID from the `promotionProducts` relationship
+   - Set `productId` to that value (not null)
+   - If `promotionProducts` is empty, then `productId` can be `null`
+
+2. **Implementation Logic**:
+   ```typescript
+   // Pseudo-code for backend
+   productId: promotion.promotionProducts?.length > 0 
+     ? promotion.promotionProducts[0].productId 
+     : null
+   ```
+
+3. **Why This Matters**:
+   - Frontend uses `productId` to look up product names in the products list
+   - Without it, promotions show "No product" or "Product #81" instead of actual product names
+   - Frontend filtering and search functionality breaks without this field
+
+---
+
+## Frontend Code Locations
+
+### Key Files
+
+1. **API Client**: `services/api/endpoints/promotions.ts`
+   - Defines all API endpoints
+   - Uses Swagger types from `services/api/types/swagger.ts`
+
+2. **Redux Thunks**: `features/store/promotions/thunks.ts`
+   - `findPromotions()` - Get all promotions
+   - `findActivePromotions()` - Get active promotions (with optional store filtering)
+   - `createPromotion()` - Create new promotion
+   - `updatePromotion()` - Update existing promotion
+   - `deletePromotion()` - Delete promotion
+
+3. **Redux Slice**: `features/store/promotions/slice.ts`
+   - Manages promotion state in Redux store
+   - Handles loading/error states
+
+4. **Admin View**: `app/(admin)/view-promotion.tsx`
+   - Displays all promotions
+   - Allows toggling active status
+   - Allows deleting promotions
+   - **Uses**: `promo.productId` to get product name (line 141, 50)
+
+5. **Retailer Promotions**: `app/(retailers)/promotions.tsx`
+   - Create/edit promotions
+   - Sends `productIds` array in create request (line 409)
+
+6. **Consumer Views**: 
+   - `app/(consumers)/index.tsx` - Shows active promotions on home
+   - `app/(consumers)/storedetails.tsx` - Shows promotions for a store
+   - `app/(consumers)/explore.tsx` - Shows promotions in explore view
+
+---
+
+## Type Handling
+
+### Type Field
+- **Backend sends**: `"PERCENTAGE"` or `"FIXED"` (uppercase)
+- **Frontend handles**: Case-insensitive comparison using `.toLowerCase()`
+- **Display**: 
+  - Percentage: `"20%"` 
+  - Fixed: `"₱50"`
+
+### Date Fields
+- **Format**: ISO 8601 strings (e.g., `"2025-12-11T00:33:00.000Z"`)
+- **Frontend expects**: String format, not Date objects
+- **Nullable**: `endsAt` can be `null` for ongoing promotions
+
+---
+
+## Filtering & Search
+
+### Active Promotions Filtering
+- Frontend filters by `active === true`
+- Also checks `startsAt` and `endsAt` dates (handled by backend `/promotions/active` endpoint)
+
+### Store-Based Filtering
+- If `storeId` provided to `findActivePromotions(storeId)`:
+  1. Frontend fetches all active promotions
+  2. Frontend fetches products for that store
+  3. Frontend filters promotions where `promotion.productId` matches a product from that store
+
+### Search Functionality
+- Admin view searches by:
+  - Promotion title
+  - Product name (looked up via `productId`)
+
+---
+
+## Summary of Required Backend Changes
+
+1. ✅ **Populate `productId` field** in all promotion responses
+   - Use first product from `promotionProducts` array if available
+   - This field is critical for frontend to display and filter promotions
+
+2. ✅ **Maintain `promotionProducts` array** (optional but recommended)
+   - Can be used for detailed product information
+   - Frontend can be enhanced later to use this for multi-product display
+
+3. ✅ **Ensure `type` field** is consistent (uppercase is fine, frontend handles it)
+
+4. ✅ **Ensure date fields** are ISO 8601 strings
+
+---
+
+## Testing Checklist
+
+After backend changes, verify:
+- [ ] Promotions display in admin view (`/admin/view-promotion`)
+- [ ] Product names show correctly (not "No product" or "Product #81")
+- [ ] Search by product name works
+- [ ] Active promotions filter works
+- [ ] Store-based filtering works (retailer dashboard)
+- [ ] Consumer views show promotions correctly
+- [ ] Creating promotions works (retailer flow)
+- [ ] Updating promotion active status works
+- [ ] Deleting promotions works
+

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -19,7 +19,7 @@ const { width } = Dimensions.get("window");
 
 export default function AdminDashboard() {
   const { state: authState, action: authActions } = useLogin();
-  const { action: storeActions, state: { promotions, products, stores, subscriptions, subscriptionAnalytics, loading: storeLoading } } = useStore();
+  const { action: storeActions, state: { promotions, products, stores, subscriptionAnalytics, loading: storeLoading } } = useStore();
   const { state: catalogState, action: catalogActions } = useCatalog();
   const router = useRouter();
 
@@ -61,8 +61,6 @@ export default function AdminDashboard() {
     const productsArray = Array.isArray(products) ? products : [];
     const promotionsArray = Array.isArray(promotions) ? promotions : [];
     const categoriesArray = Array.isArray(catalogState.categories) ? catalogState.categories : [];
-    const subscriptionsArray = Array.isArray(subscriptions) ? subscriptions : [];
-    
     const totalUsers = allUsers.length;
     const consumers = allUsers.filter(u => u.role === "CONSUMER").length;
     const retailers = allUsers.filter(u => u.role === "RETAILER").length;
@@ -80,9 +78,10 @@ export default function AdminDashboard() {
     
     const totalCategories = categoriesArray.length;
     
-    const totalSubscriptions = subscriptionsArray.length;
-    const activeSubscriptions = subscriptionsArray.filter(s => s.isActive !== false).length;
-    const revenue = typeof subscriptionAnalytics?.totalRevenue === 'number' ? subscriptionAnalytics.totalRevenue : 0;
+    // Subscription analytics from API
+    const totalSubscriptions = subscriptionAnalytics?.totalUsers || 0;
+    const activeSubscriptions = subscriptionAnalytics?.proUsers || 0;
+    const revenue = subscriptionAnalytics?.revenue?.monthly || 0;
     
     // Calculate average discount
     const totalDiscount = promotionsArray.reduce((sum, p) => sum + (p.discount || 0), 0);
@@ -114,7 +113,7 @@ export default function AdminDashboard() {
       avgDiscount,
       recentUsersToday,
     };
-  }, [authState.allUsers, stores, products, promotions, catalogState.categories, subscriptions, subscriptionAnalytics]);
+  }, [authState.allUsers, stores, products, promotions, catalogState.categories, subscriptionAnalytics]);
 
   // Format time ago for recent users
   const getTimeAgo = (createdAt: string) => {

--- a/app/(admin)/subscriptions.tsx
+++ b/app/(admin)/subscriptions.tsx
@@ -34,6 +34,20 @@ export default function SubscriptionAnalytics() {
     return num.toLocaleString("en-US");
   };
 
+  const analytics = subscriptionAnalytics;
+
+  // Calculate derived metrics from API data
+  const totalUsers = analytics?.totalUsers || 0;
+  const basicUsers = analytics?.basicUsers || 0;
+  const proUsers = analytics?.proUsers || 0;
+  const monthlyRevenue = analytics?.revenue?.monthly || 0;
+  const yearlyRevenue = analytics?.revenue?.yearly || 0;
+  
+  // Get role-based breakdowns
+  const consumerStats = analytics?.byRoleAndTier?.consumer;
+  const retailerStats = analytics?.byRoleAndTier?.retailer;
+  const adminStats = analytics?.byRoleAndTier?.admin;
+
   if (loading && !subscriptionAnalytics) {
     return (
       <View style={styles.container}>
@@ -45,8 +59,6 @@ export default function SubscriptionAnalytics() {
       </View>
     );
   }
-
-  const analytics = subscriptionAnalytics;
 
   return (
     <View style={styles.container}>
@@ -62,13 +74,19 @@ export default function SubscriptionAnalytics() {
                 <Text style={[styles.cardLabel, styles.primaryCardText]}>Total Users</Text>
               </View>
               <Text style={[styles.cardValue, styles.primaryCardText]}>
-                {analytics ? formatNumber(analytics.total) : "0"}
+                {formatNumber(totalUsers)}
               </Text>
               <View style={[styles.cardFooter, styles.primaryCardFooter]}>
                 <View style={styles.footerItem}>
-                  <Text style={[styles.footerLabel, styles.primaryCardText]}>Active</Text>
+                  <Text style={[styles.footerLabel, styles.primaryCardText]}>Basic</Text>
                   <Text style={[styles.footerValue, styles.primaryCardText]}>
-                    {analytics ? formatNumber(analytics.active) : "0"}
+                    {formatNumber(basicUsers)}
+                  </Text>
+                </View>
+                <View style={styles.footerItem}>
+                  <Text style={[styles.footerLabel, styles.primaryCardText]}>Pro</Text>
+                  <Text style={[styles.footerValue, styles.primaryCardText]}>
+                    {formatNumber(proUsers)}
                   </Text>
                 </View>
               </View>
@@ -77,16 +95,16 @@ export default function SubscriptionAnalytics() {
             <View style={styles.overviewCard}>
               <View style={styles.cardHeader}>
                 <Ionicons name="cash" size={24} color="#10B981" />
-                <Text style={styles.cardLabel}>Total Revenue</Text>
+                <Text style={styles.cardLabel}>Monthly Revenue</Text>
               </View>
               <Text style={[styles.cardValue, styles.revenueValue]}>
-                {analytics ? formatCurrency(analytics.totalRevenue) : "₱0.00"}
+                {formatCurrency(monthlyRevenue)}
               </Text>
               <View style={styles.cardFooter}>
                 <View style={styles.footerItem}>
-                  <Text style={styles.footerLabel}>Avg Price</Text>
+                  <Text style={styles.footerLabel}>Yearly</Text>
                   <Text style={styles.footerValue}>
-                    {analytics ? formatCurrency(analytics.averagePrice) : "₱0.00"}
+                    {formatCurrency(yearlyRevenue)}
                   </Text>
                 </View>
               </View>
@@ -94,17 +112,17 @@ export default function SubscriptionAnalytics() {
 
             <View style={styles.overviewCard}>
               <View style={styles.cardHeader}>
-                <Ionicons name="calendar" size={24} color="#FFBE5D" />
-                <Text style={styles.cardLabel}>This Month</Text>
+                <Ionicons name="stats-chart" size={24} color="#FFBE5D" />
+                <Text style={styles.cardLabel}>Tier Distribution</Text>
               </View>
               <Text style={styles.cardValue}>
-                {analytics ? formatNumber(analytics.subscriptionsThisMonth) : "0"}
+                {formatNumber(proUsers)}
               </Text>
               <View style={styles.cardFooter}>
                 <View style={styles.footerItem}>
-                  <Text style={styles.footerLabel}>Recent (30d)</Text>
+                  <Text style={styles.footerLabel}>Pro Users</Text>
                   <Text style={styles.footerValue}>
-                    {analytics ? formatNumber(analytics.recentSubscriptions) : "0"}
+                    {formatNumber(basicUsers)} Basic
                   </Text>
                 </View>
               </View>
@@ -112,124 +130,105 @@ export default function SubscriptionAnalytics() {
           </View>
         </View>
 
-        {/* Status Breakdown */}
+        {/* Role & Tier Breakdown */}
         {analytics && (
           <>
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Status Breakdown</Text>
+              <Text style={styles.sectionTitle}>Tier Breakdown</Text>
               <View style={styles.breakdownCard}>
                 <View style={styles.breakdownRow}>
                   <View style={styles.breakdownItem}>
-                    <View style={[styles.statusIndicator, { backgroundColor: "#10B981" }]} />
-                    <Text style={styles.breakdownLabel}>Active</Text>
-                    <Text style={styles.breakdownValue}>{formatNumber(analytics.active)}</Text>
+                    <View style={[styles.statusIndicator, { backgroundColor: "#277874" }]} />
+                    <Text style={styles.breakdownLabel}>Basic</Text>
+                    <Text style={styles.breakdownValue}>{formatNumber(basicUsers)}</Text>
                   </View>
                   <View style={styles.breakdownItem}>
-                    <View style={[styles.statusIndicator, { backgroundColor: "#EF4444" }]} />
-                    <Text style={styles.breakdownLabel}>Cancelled</Text>
-                    <Text style={styles.breakdownValue}>{formatNumber(analytics.cancelled || 0)}</Text>
-                  </View>
-                  <View style={styles.breakdownItem}>
-                    <View style={[styles.statusIndicator, { backgroundColor: "#6B7280" }]} />
-                    <Text style={styles.breakdownLabel}>Expired</Text>
-                    <Text style={styles.breakdownValue}>{formatNumber(analytics.expired || 0)}</Text>
-                  </View>
-                  <View style={styles.breakdownItem}>
-                    <View style={[styles.statusIndicator, { backgroundColor: "#F59E0B" }]} />
-                    <Text style={styles.breakdownLabel}>Pending</Text>
-                    <Text style={styles.breakdownValue}>{formatNumber(analytics.pending || 0)}</Text>
+                    <View style={[styles.statusIndicator, { backgroundColor: "#FFBE5D" }]} />
+                    <Text style={styles.breakdownLabel}>Pro</Text>
+                    <Text style={styles.breakdownValue}>{formatNumber(proUsers)}</Text>
                   </View>
                 </View>
               </View>
             </View>
 
-            {/* Plan Distribution */}
-            {analytics.byPlan && analytics.byPlan.length > 0 && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Plan Distribution</Text>
-                <View style={styles.distributionCard}>
-                  {analytics.byPlan.map((item, index) => (
-                    <View key={index} style={styles.distributionRow}>
-                      <View style={styles.distributionLeft}>
-                        <View
-                          style={[
-                            styles.planBadge,
-                            {
-                              backgroundColor:
-                                item.plan === "PRO"
-                                  ? "#FFBE5D"
-                                  : item.plan === "BASIC"
-                                  ? "#277874"
-                                  : "#6B7280",
-                            },
-                          ]}
-                        >
-                          <Text style={styles.planBadgeText}>{item.plan}</Text>
-                        </View>
-                        <Text style={styles.distributionLabel}>{item.plan} Plan</Text>
-                      </View>
-                      <Text style={styles.distributionValue}>{formatNumber(item.count)}</Text>
+            {/* Role Distribution */}
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>By Role & Tier</Text>
+              <View style={styles.distributionCard}>
+                {/* Consumers */}
+                {consumerStats && (
+                  <View style={styles.distributionRow}>
+                    <View style={styles.distributionLeft}>
+                      <Ionicons name="people" size={20} color="#277874" />
+                      <Text style={styles.distributionLabel}>Consumers</Text>
                     </View>
-                  ))}
-                </View>
-              </View>
-            )}
+                    <View style={styles.distributionRight}>
+                      <Text style={styles.distributionValue}>{formatNumber(consumerStats.total)}</Text>
+                      <Text style={styles.distributionSubtext}>
+                        {formatNumber(consumerStats.basic)} Basic, {formatNumber(consumerStats.pro)} Pro
+                      </Text>
+                    </View>
+                  </View>
+                )}
 
-            {/* Billing Cycle Distribution */}
-            {analytics.byBillingCycle && analytics.byBillingCycle.length > 0 && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Billing Cycle</Text>
-                <View style={styles.distributionCard}>
-                  {analytics.byBillingCycle.map((item, index) => (
-                    <View key={index} style={styles.distributionRow}>
-                      <View style={styles.distributionLeft}>
-                        <Ionicons
-                          name={item.billingCycle === "YEARLY" ? "calendar" : "calendar-outline"}
-                          size={20}
-                          color="#277874"
-                        />
-                        <Text style={styles.distributionLabel}>
-                          {item.billingCycle === "MONTHLY" ? "Monthly" : "Yearly"}
-                        </Text>
-                      </View>
-                      <Text style={styles.distributionValue}>{formatNumber(item.count)}</Text>
+                {/* Retailers */}
+                {retailerStats && (
+                  <View style={styles.distributionRow}>
+                    <View style={styles.distributionLeft}>
+                      <Ionicons name="storefront" size={20} color="#277874" />
+                      <Text style={styles.distributionLabel}>Retailers</Text>
                     </View>
-                  ))}
-                </View>
-              </View>
-            )}
+                    <View style={styles.distributionRight}>
+                      <Text style={styles.distributionValue}>{formatNumber(retailerStats.total)}</Text>
+                      <Text style={styles.distributionSubtext}>
+                        {formatNumber(retailerStats.basic)} Basic, {formatNumber(retailerStats.pro)} Pro
+                      </Text>
+                    </View>
+                  </View>
+                )}
 
-            {/* Status Distribution */}
-            {analytics.byStatus && analytics.byStatus.length > 0 && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Status Distribution</Text>
-                <View style={styles.distributionCard}>
-                  {analytics.byStatus.map((item, index) => (
-                    <View key={index} style={styles.distributionRow}>
-                      <View style={styles.distributionLeft}>
-                        <View
-                          style={[
-                            styles.statusDot,
-                            {
-                              backgroundColor:
-                                item.status === "ACTIVE"
-                                  ? "#10B981"
-                                  : item.status === "CANCELLED"
-                                  ? "#EF4444"
-                                  : item.status === "EXPIRED"
-                                  ? "#6B7280"
-                                  : "#F59E0B",
-                            },
-                          ]}
-                        />
-                        <Text style={styles.distributionLabel}>{item.status}</Text>
-                      </View>
-                      <Text style={styles.distributionValue}>{formatNumber(item.count)}</Text>
+                {/* Admins */}
+                {adminStats && (
+                  <View style={styles.distributionRow}>
+                    <View style={styles.distributionLeft}>
+                      <Ionicons name="shield" size={20} color="#277874" />
+                      <Text style={styles.distributionLabel}>Admins</Text>
                     </View>
-                  ))}
+                    <View style={styles.distributionRight}>
+                      <Text style={styles.distributionValue}>{formatNumber(adminStats.total)}</Text>
+                      <Text style={styles.distributionSubtext}>
+                        {formatNumber(adminStats.basic)} Basic, {formatNumber(adminStats.pro)} Pro
+                      </Text>
+                    </View>
+                  </View>
+                )}
+              </View>
+            </View>
+
+            {/* Revenue Breakdown */}
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Revenue Breakdown</Text>
+              <View style={styles.distributionCard}>
+                <View style={styles.distributionRow}>
+                  <View style={styles.distributionLeft}>
+                    <Ionicons name="calendar-outline" size={20} color="#10B981" />
+                    <Text style={styles.distributionLabel}>Monthly</Text>
+                  </View>
+                  <Text style={[styles.distributionValue, styles.revenueValue]}>
+                    {formatCurrency(monthlyRevenue)}
+                  </Text>
+                </View>
+                <View style={styles.distributionRow}>
+                  <View style={styles.distributionLeft}>
+                    <Ionicons name="calendar" size={20} color="#10B981" />
+                    <Text style={styles.distributionLabel}>Yearly</Text>
+                  </View>
+                  <Text style={[styles.distributionValue, styles.revenueValue]}>
+                    {formatCurrency(yearlyRevenue)}
+                  </Text>
                 </View>
               </View>
-            )}
+            </View>
           </>
         )}
 
@@ -398,6 +397,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 12,
+    flex: 1,
+  },
+  distributionRight: {
+    alignItems: "flex-end",
   },
   planBadge: {
     paddingHorizontal: 10,
@@ -418,6 +421,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "bold",
     color: "#277874",
+  },
+  distributionSubtext: {
+    fontSize: 12,
+    color: "#6B7280",
+    marginTop: 2,
   },
   statusDot: {
     width: 10,

--- a/app/(admin)/view-promotion.tsx
+++ b/app/(admin)/view-promotion.tsx
@@ -43,7 +43,7 @@ export default function AdminViewPromotions() {
     return !!(store.ownerId && !authState.allUsers.some((u) => u.id === store.ownerId));
   };
 
-  const promotions = storeState.promotions
+  const promotions = (storeState.promotions || [])
     .filter((p) => (showOnlyActive ? p.active : true))
     .filter((p) => {
       const title = (p.title || "").toLowerCase();
@@ -151,7 +151,7 @@ export default function AdminViewPromotions() {
                       <View style={[styles.metaPill, { backgroundColor: "#e0f2f1" }]}>
                         <Ionicons name="pricetag" size={14} color="#277874" />
                         <Text style={[styles.metaText, { color: "#277874" }]}>
-                          {promo.type === "percentage" ? `${promo.discount}%` : `₱${promo.discount}`}
+                          {promo.type?.toLowerCase() === "percentage" ? `${promo.discount}%` : `₱${promo.discount}`}
                         </Text>
                       </View>
                       <View style={[styles.metaPill, { backgroundColor: "#f3f4f6" }]}>

--- a/app/(consumers)/categories.tsx
+++ b/app/(consumers)/categories.tsx
@@ -184,7 +184,7 @@ export default function CategoriesPage() {
       }
       // If no match found, it will default to "All Items" via the existing useEffect below
     }
-  }, [params.category, availableCategories]);
+  }, [params.category]);
 
   const getProductCategoryName = useCallback(
     (product: CatalogProduct | StoreProduct): string => {

--- a/app/(retailers)/components/PromotionCard.tsx
+++ b/app/(retailers)/components/PromotionCard.tsx
@@ -32,19 +32,29 @@ export function PromotionCard({ promotion, activePromotions }: PromotionCardProp
 
   // Find all products associated with this promotion
   useEffect(() => {
-    const productIds = promotion.productIds || [promotion.productId];
+    const productIds = promotion.productIds || (promotion.productId ? [promotion.productId] : []);
     
-    if (productIds.length > 0 && products.length > 0) {
-      const foundProducts = productIds.map((id: number) => 
+    // Filter out invalid IDs (null, undefined, NaN, or non-positive numbers)
+    const validProductIds = productIds.filter((id: number | null | undefined) => 
+      id != null && Number.isFinite(id) && id > 0
+    ) as number[];
+    
+    if (validProductIds.length > 0 && products.length > 0) {
+      const foundProducts = validProductIds.map((id: number) => 
         products.find(p => p.id === id)
       ).filter(Boolean);
       
       setPromotionProducts(foundProducts);
       
       // If some products are missing, try to fetch them
-      const missingIds = productIds.filter((id: number) => !products.find(p => p.id === id));
+      const missingIds = validProductIds.filter((id: number) => !products.find(p => p.id === id));
       if (missingIds.length > 0) {
-        missingIds.forEach((id: number) => findProductById(id));
+        missingIds.forEach((id: number) => {
+          // Double-check the ID is valid before making API call
+          if (id != null && Number.isFinite(id) && id > 0) {
+            findProductById(id);
+          }
+        });
       }
     }
   }, [promotion.productIds, promotion.productId, products, findProductById]);

--- a/app/(retailers)/promotions.tsx
+++ b/app/(retailers)/promotions.tsx
@@ -406,7 +406,7 @@ export default function Promotions() {
           startsAt: start.toISOString(),
           endsAt: end.toISOString(),
           discount: parseFloat(productData.discount),
-          productId: parseInt(productId),
+          productIds: [parseInt(productId)],
         };
         console.log(`Creating promotion for product ${productId}:`, promotionPayload);
         return createPromotion(promotionPayload).unwrap();
@@ -1228,7 +1228,7 @@ export default function Promotions() {
                                             startsAt: editForm.startsAt.toISOString(),
                                             endsAt: editForm.endsAt.toISOString(),
                                             discount: discount,
-                                            productId: createdProduct.id,
+                                            productIds: [createdProduct.id],
                                           }).unwrap();
                                         }
                                         
@@ -1350,7 +1350,7 @@ export default function Promotions() {
                                                     startsAt: editForm.startsAt.toISOString(),
                                                     endsAt: editForm.endsAt.toISOString(),
                                                     discount: discountValue,
-                                                    productId: product.id,
+                                                    productIds: [product.id],
                                                   }).unwrap();
                                                   if (storeId) {
                                                     await findActivePromotions(storeId);

--- a/components/consumers/explore/PromotionCard.tsx
+++ b/components/consumers/explore/PromotionCard.tsx
@@ -52,14 +52,10 @@ export default function PromotionCard({ promotion, onPress }: PromotionCardProps
       return;
     }
 
-    if (promotion.productId) {
-      router.push({
-        pathname: "/(consumers)/product",
-        params: {
-          productId: promotion.productId.toString(),
-        },
-      });
-    }
+    // PromotionRecommendationItemDto doesn't have productId, only productCount
+    // Navigate to promotions list or handle differently
+    // For now, just do nothing or navigate to a promotions page
+    // TODO: Implement proper navigation for multi-product promotions
   };
 
   return (

--- a/features/store/hooks.ts
+++ b/features/store/hooks.ts
@@ -7,13 +7,6 @@ import { useAppDispatch, useAppSelector } from "@/store/hooks";
 // Store domain hooks
 import * as storesSelectors from "./stores/selectors";
 import * as storesThunks from "./stores/thunks";
-import { 
-  getActiveSubscription, 
-  joinSubscription, 
-  cancelRetailerSubscription, 
-  updateRetailerSubscription,
-  findSubscriptions 
-} from "./thunk";
 
 // Product domain hooks
 import * as productsSelectors from "./products/selectors";
@@ -40,8 +33,6 @@ export function useStores() {
       selectedStore: useAppSelector(storesSelectors.selectSelectedStore),
       userStore: useAppSelector(storesSelectors.selectUserStore),
       nearbyStores: useAppSelector(storesSelectors.selectNearbyStores),
-      activeSubscription: useAppSelector(storesSelectors.selectActiveSubscription),
-      subscriptions: useAppSelector(storesSelectors.selectSubscriptions),
       loading: storesState.loading,
       error: storesState.error,
     },
@@ -65,16 +56,6 @@ export function useStores() {
       ) => dispatch(storesThunks.updateStoreAdminStatus(data)),
       deleteStore: (storeId: number) =>
         dispatch(storesThunks.deleteStore(storeId)),
-      getActiveSubscription: (userId: number) =>
-        dispatch(getActiveSubscription(userId)),
-      joinSubscription: (data: { subscriptionId: number }) =>
-        dispatch(joinSubscription(data)),
-      cancelRetailerSubscription: () =>
-        dispatch(cancelRetailerSubscription()),
-      updateRetailerSubscription: (data: { subscriptionId: number }) =>
-        dispatch(updateRetailerSubscription(data)),
-      findSubscriptions: (filters?: { plan?: "FREE" | "BASIC" | "PREMIUM"; isActive?: boolean; search?: string; skip?: number; take?: number }) =>
-        dispatch(findSubscriptions(filters || {})),
     },
   };
 }
@@ -185,8 +166,6 @@ export function useStore() {
       selectedStore: stores.state.selectedStore,
       userStore: stores.state.userStore,
       nearbyStores: stores.state.nearbyStores,
-      activeSubscription: stores.state.activeSubscription,
-      subscriptions: stores.state.subscriptions,
       products: products.state.products,
       promotions: promotions.state.promotions,
       activePromotions: promotions.state.activePromotions,
@@ -213,11 +192,6 @@ export function useStore() {
       updateStore: stores.actions.updateStore,
       updateStoreAdminStatus: stores.actions.updateStoreAdminStatus,
       deleteStore: stores.actions.deleteStore,
-      getActiveSubscription: stores.actions.getActiveSubscription,
-      joinSubscription: stores.actions.joinSubscription,
-      cancelRetailerSubscription: stores.actions.cancelRetailerSubscription,
-      updateRetailerSubscription: stores.actions.updateRetailerSubscription,
-      findSubscriptions: stores.actions.findSubscriptions,
       // Product actions
       findProducts: products.actions.findProducts,
       findProductById: products.actions.findProductById,

--- a/features/store/index.ts
+++ b/features/store/index.ts
@@ -25,4 +25,4 @@ export { useStoreManagement } from "./storeManagement";
 export type { Store, CreateStoreDTO, UpdateStoreDTO } from "./stores/types";
 export type { Product, CreateProductDTO, UpdateProductDTO } from "./products/types";
 // Promotion types already exported above, no need to re-export
-export type { Subscription, SubscriptionAnalytics } from "./subscriptions/types";
+export type { SubscriptionAnalytics } from "./subscriptions/types";

--- a/features/store/products/thunks.ts
+++ b/features/store/products/thunks.ts
@@ -43,6 +43,13 @@ export const findProductById = createAsyncThunk<
   number,
   { rejectValue: { message: string }; state: RootState }
 >("products/findProductById", async (productId, { rejectWithValue }) => {
+  // Validate productId before making API call
+  if (!productId || !Number.isFinite(productId) || productId <= 0) {
+    return rejectWithValue({
+      message: "Invalid product ID",
+    });
+  }
+
   try {
     const product = await productsApi.findProductById(productId);
     if (!product) {

--- a/features/store/promotions/thunks.ts
+++ b/features/store/promotions/thunks.ts
@@ -14,7 +14,20 @@ export const findPromotions = createAsyncThunk<
   { rejectValue: { message: string }; state: RootState }
 >("promotions/findPromotions", async (_, { rejectWithValue }) => {
   try {
-    return await promotionsApi.findPromotions();
+    const apiPromotions: any[] = await promotionsApi.findPromotions();
+    // Map API promotions to extract productId from promotionProducts if needed
+    return apiPromotions.map((p: any) => {
+      // Extract productId from promotionProducts if productId is not present
+      let productId = p.productId ?? null;
+      if (!productId && p.promotionProducts && p.promotionProducts.length > 0) {
+        productId = p.promotionProducts[0].productId ?? null;
+      }
+      
+      return {
+        ...p,
+        productId: productId,
+      };
+    });
   } catch (error) {
     return rejectWithValue({
       message:
@@ -33,10 +46,24 @@ export const findActivePromotions = createAsyncThunk<
   "promotions/findActivePromotions",
   async ({ storeId }, { rejectWithValue, getState }) => {
     try {
-      const allPromotions = await promotionsApi.findPromotions();
+      const allPromotions: any[] = await promotionsApi.findPromotions();
+      
+      // Map and extract productId from promotionProducts if needed
+      let mappedPromotions = allPromotions.map((p: any) => {
+        // Extract productId from promotionProducts if productId is not present
+        let productId = p.productId ?? null;
+        if (!productId && p.promotionProducts && p.promotionProducts.length > 0) {
+          productId = p.promotionProducts[0].productId ?? null;
+        }
+        
+        return {
+          ...p,
+          productId: productId,
+        };
+      });
       
       // Filter for active promotions
-      let activePromotions = allPromotions.filter(
+      let activePromotions = mappedPromotions.filter(
         (promotion: Promotion) => promotion.active === true
       );
       
@@ -69,7 +96,18 @@ export const createPromotion = createAsyncThunk<
   { rejectValue: { message: string }; state: RootState }
 >("promotions/createPromotion", async (promotionData, { rejectWithValue }) => {
   try {
-    return await promotionsApi.createPromotion(promotionData);
+    const result: any = await promotionsApi.createPromotion(promotionData);
+    
+    // Extract productId from promotionProducts if productId is not present
+    let productId = result.productId ?? null;
+    if (!productId && result.promotionProducts && result.promotionProducts.length > 0) {
+      productId = result.promotionProducts[0].productId ?? null;
+    }
+    
+    return {
+      ...result,
+      productId: productId,
+    };
   } catch (error) {
     return rejectWithValue({
       message:
@@ -86,7 +124,18 @@ export const updatePromotion = createAsyncThunk<
   { rejectValue: { message: string }; state: RootState }
 >("promotions/updatePromotion", async ({ id, ...updateData }, { rejectWithValue }) => {
   try {
-    return await promotionsApi.updatePromotion(id, updateData);
+    const result: any = await promotionsApi.updatePromotion(id, updateData);
+    
+    // Extract productId from promotionProducts if productId is not present
+    let productId = result.productId ?? null;
+    if (!productId && result.promotionProducts && result.promotionProducts.length > 0) {
+      productId = result.promotionProducts[0].productId ?? null;
+    }
+    
+    return {
+      ...result,
+      productId: productId,
+    };
   } catch (error) {
     return rejectWithValue({
       message:

--- a/features/store/promotions/types.ts
+++ b/features/store/promotions/types.ts
@@ -18,6 +18,9 @@ export type {
 
 // Aliases for backward compatibility
 export type Promotion = PromotionResponseDto;
-export type CreatePromotionDTO = CreatePromotionDto;
+// CreatePromotionDTO with backward compatibility for productId
+export type CreatePromotionDTO = CreatePromotionDto & {
+  productId?: number; // Legacy field, will be converted to productIds array
+};
 export type UpdatePromotionDTO = UpdatePromotionDto;
 

--- a/features/store/stores/selectors.ts
+++ b/features/store/stores/selectors.ts
@@ -55,13 +55,3 @@ export const selectActiveStores = createSelector(
   (stores) => stores.filter((store) => store.isActive !== false)
 );
 
-export const selectActiveSubscription = createSelector(
-  [selectStoresState],
-  (storesState) => storesState.activeSubscription
-);
-
-export const selectSubscriptions = createSelector(
-  [selectStoresState],
-  (storesState) => storesState.subscriptions
-);
-

--- a/features/store/stores/slice.ts
+++ b/features/store/stores/slice.ts
@@ -13,25 +13,16 @@ import {
   updateStoreAdminStatus,
   deleteStore,
 } from "./thunks";
-import { 
-  getActiveSubscription, 
-  joinSubscription, 
-  cancelRetailerSubscription, 
-  updateRetailerSubscription,
-  findSubscriptions 
-} from "../thunk";
-import type { Subscription } from "../types";
 import { createAsyncReducer } from "@/utils/redux/createAsyncReducer";
 import { logout } from "@/features/auth/slice";
-import type { Store, CreateStoreDTO, UpdateStoreDTO, UserSubscription } from "../types";
+import type { Store, CreateStoreDTO, UpdateStoreDTO } from "../types";
+import type { StoreResponseDto } from "@/services/api/types/swagger";
 
 interface StoresState {
   stores: Store[];
   selectedStore: Store | null;
   userStore: Store | null;
   nearbyStores: Store[];
-  activeSubscription: UserSubscription | null;
-  subscriptions: Subscription[];
   loading: boolean;
   error: string | null;
 }
@@ -41,8 +32,6 @@ const initialState: StoresState = {
   selectedStore: null,
   userStore: null,
   nearbyStores: [],
-  activeSubscription: null,
-  subscriptions: [],
   loading: false,
   error: null,
 };
@@ -56,8 +45,6 @@ const storesSlice = createSlice({
       state.selectedStore = null;
       state.userStore = null;
       state.nearbyStores = [];
-      state.activeSubscription = null;
-      state.subscriptions = [];
       state.loading = false;
       state.error = null;
     },
@@ -133,9 +120,10 @@ const storesSlice = createSlice({
     });
 
     // Create Store
-    createAsyncReducer<StoresState, Store, CreateStoreDTO>(builder, createStore, {
+    // Note: createStore returns StoreResponseDto which is compatible with Store
+    createAsyncReducer<StoresState, StoreResponseDto, CreateStoreDTO>(builder, createStore as any, {
       onFulfilled: (state: Draft<StoresState>, action) => {
-        state.userStore = action.payload;
+        state.userStore = action.payload as Store;
         state.selectedStore = action.payload;
         // Add to stores list if not already present
         const existingIndex = state.stores.findIndex(
@@ -196,49 +184,12 @@ const storesSlice = createSlice({
       },
     });
 
-    // Get Active Subscription
-    createAsyncReducer<StoresState, UserSubscription | null, number>(builder, getActiveSubscription, {
-      onFulfilled: (state: Draft<StoresState>, action) => {
-        state.activeSubscription = action.payload;
-      },
-    });
-
-    // Join Subscription
-    createAsyncReducer<StoresState, UserSubscription, any>(builder, joinSubscription, {
-      onFulfilled: (state: Draft<StoresState>, action) => {
-        state.activeSubscription = action.payload;
-      },
-    });
-
-    // Cancel Retailer Subscription
-    createAsyncReducer<StoresState, UserSubscription, void>(builder, cancelRetailerSubscription, {
-      onFulfilled: (state: Draft<StoresState>, action) => {
-        state.activeSubscription = action.payload;
-      },
-    });
-
-    // Update Retailer Subscription
-    createAsyncReducer<StoresState, UserSubscription, any>(builder, updateRetailerSubscription, {
-      onFulfilled: (state: Draft<StoresState>, action) => {
-        state.activeSubscription = action.payload;
-      },
-    });
-
-    // Find Subscriptions
-    createAsyncReducer<StoresState, Subscription[], any>(builder, findSubscriptions, {
-      onFulfilled: (state: Draft<StoresState>, action) => {
-        state.subscriptions = action.payload;
-      },
-    });
-
     // Clear stores on logout
     builder.addCase(logout, (state) => {
       state.stores = [];
       state.selectedStore = null;
       state.userStore = null;
       state.nearbyStores = [];
-      state.activeSubscription = null;
-      state.subscriptions = [];
       state.loading = false;
       state.error = null;
     });

--- a/features/store/stores/thunks.ts
+++ b/features/store/stores/thunks.ts
@@ -99,7 +99,9 @@ export const createStore = createAsyncThunk<
   { rejectValue: { message: string }; state: RootState }
 >("stores/createStore", async (storeData, { rejectWithValue }) => {
   try {
-    return await storesApi.createStore(storeData);
+    const result = await storesApi.createStore(storeData);
+    // Store type matches StoreResponseDto, so this is safe
+    return result;
   } catch (error) {
     return rejectWithValue({
       message:

--- a/features/store/subscriptions/slice.ts
+++ b/features/store/subscriptions/slice.ts
@@ -13,6 +13,7 @@ import {
 import { createAsyncReducer } from "@/utils/redux/createAsyncReducer";
 import { logout } from "@/features/auth/slice";
 import type { SubscriptionTier, SubscriptionAnalytics } from "./types";
+import type { SubscriptionAnalyticsDto } from "@/services/api/types/swagger";
 
 interface SubscriptionsState {
   currentTier: SubscriptionTier | null;
@@ -62,9 +63,9 @@ const subscriptionsSlice = createSlice({
     });
 
     // Get Subscription Analytics
-    createAsyncReducer<SubscriptionsState, SubscriptionAnalytics, void>(builder, getSubscriptionAnalytics, {
+    createAsyncReducer<SubscriptionsState, SubscriptionAnalyticsDto, void>(builder, getSubscriptionAnalytics, {
       onFulfilled: (state: Draft<SubscriptionsState>, action) => {
-        state.subscriptionAnalytics = action.payload;
+        state.subscriptionAnalytics = action.payload as SubscriptionAnalytics;
       },
     });
 

--- a/hooks/useNearbyPromotionNotifications.ts
+++ b/hooks/useNearbyPromotionNotifications.ts
@@ -9,6 +9,8 @@ import { Alert, AppState, AppStateStatus } from "react-native";
 const LOCATION_CHECK_INTERVAL = 60000; // 60 seconds - minimal data usage
 const MIN_DISTANCE_CHANGE_KM = 0.1; // Only check if moved at least 100m
 
+type IntervalId = ReturnType<typeof setInterval>;
+
 interface TrackedPromotion {
   promotionId: number;
   storeId: number;
@@ -31,7 +33,7 @@ export function useNearbyPromotionNotifications() {
 
   const [isEnabled, setIsEnabled] = useState(true);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
-  const locationIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const locationIntervalRef = useRef<IntervalId | null>(null);
   const lastLocationRef = useRef<{ latitude: number; longitude: number } | null>(null);
   const notifiedPromotionsRef = useRef<Map<number, TrackedPromotion>>(new Map());
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);

--- a/services/api/endpoints/subscriptions.ts
+++ b/services/api/endpoints/subscriptions.ts
@@ -20,8 +20,9 @@ export type {
   SubscriptionAnalyticsDto,
 };
 
-// Aliases for backward compatibility
-export type SubscriptionTier = SubscriptionTierResponseDto;
+// Note: SubscriptionTier is already exported from swagger.ts as "BASIC" | "PRO"
+// Do not re-export SubscriptionTier here to avoid conflict
+// SubscriptionAnalytics is an alias for SubscriptionAnalyticsDto
 export type SubscriptionAnalytics = SubscriptionAnalyticsDto;
 
 export const subscriptionsApi = {

--- a/services/api/types/swagger.ts
+++ b/services/api/types/swagger.ts
@@ -171,7 +171,25 @@ export interface PromotionResponseDto {
   endsAt: string | null; // ISO 8601 format date-time
   active: boolean;
   discount: number;
-  productId: number | null; // Legacy field, may be null for multi-product promotions
+  productId?: number | null; // Legacy field, may be null for multi-product promotions. If missing, extract from promotionProducts[0].productId
+  promotionProducts?: Array<{
+    id: number;
+    promotionId: number;
+    productId: number;
+    createdAt: string;
+    product?: {
+      id: number;
+      name: string;
+      description: string;
+      price: string;
+      stock: number;
+      createdAt: string;
+      isActive: boolean;
+      storeId: number;
+      categoryId: number | null;
+      imageUrl: string | null;
+    };
+  }>;
 }
 
 export interface UpdatePromotionDto {

--- a/utils/typeValidation.ts
+++ b/utils/typeValidation.ts
@@ -11,8 +11,6 @@ import type {
   PromotionResponseDto,
   CategoryResponseDto,
   NotificationResponseDto,
-  SubscriptionResponseDto,
-  UserSubscriptionResponseDto,
 } from "@/services/api/types/swagger";
 
 /**
@@ -140,52 +138,6 @@ export function isNotificationResponseDto(data: unknown): data is NotificationRe
   );
 }
 
-/**
- * Type guard for SubscriptionResponseDto
- */
-export function isSubscriptionResponseDto(data: unknown): data is SubscriptionResponseDto {
-  if (!data || typeof data !== "object") return false;
-  const obj = data as Record<string, unknown>;
-  return (
-    typeof obj.id === "number" &&
-    typeof obj.name === "string" &&
-    typeof obj.plan === "string" &&
-    ["FREE", "BASIC", "PREMIUM"].includes(obj.plan) &&
-    typeof obj.billingCycle === "string" &&
-    ["MONTHLY", "YEARLY"].includes(obj.billingCycle) &&
-    typeof obj.price === "string" &&
-    typeof obj.isActive === "boolean" &&
-    typeof obj.createdAt === "string" &&
-    typeof obj.updatedAt === "string" &&
-    typeof obj.startsAt === "string" &&
-    (obj.description === null || typeof obj.description === "string") &&
-    (obj.benefits === null || typeof obj.benefits === "string") &&
-    (obj.endsAt === null || typeof obj.endsAt === "string")
-  );
-}
-
-/**
- * Type guard for UserSubscriptionResponseDto
- */
-export function isUserSubscriptionResponseDto(data: unknown): data is UserSubscriptionResponseDto {
-  if (!data || typeof data !== "object") return false;
-  const obj = data as Record<string, unknown>;
-  return (
-    typeof obj.id === "number" &&
-    typeof obj.userId === "number" &&
-    typeof obj.subscriptionId === "number" &&
-    typeof obj.status === "string" &&
-    ["ACTIVE", "CANCELLED", "EXPIRED", "PENDING"].includes(obj.status) &&
-    typeof obj.price === "string" &&
-    typeof obj.billingCycle === "string" &&
-    ["MONTHLY", "YEARLY"].includes(obj.billingCycle) &&
-    typeof obj.startsAt === "string" &&
-    typeof obj.createdAt === "string" &&
-    typeof obj.updatedAt === "string" &&
-    (obj.endsAt === null || typeof obj.endsAt === "string") &&
-    (obj.cancelledAt === null || typeof obj.cancelledAt === "string")
-  );
-}
 
 /**
  * Validate array of items with a type guard


### PR DESCRIPTION
- Updated PromotionResponseDto type to include promotionProducts array
- Modified all promotion thunks to extract productId from promotionProducts[0].productId when productId is missing
- Fixed findPromotions, findActivePromotions, createPromotion, and updatePromotion in both thunk files
- Promotions now display correctly in admin view when backend returns promotionProducts instead of productId